### PR TITLE
Feature/comment owner

### DIFF
--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -11,6 +11,7 @@ export default function Comment({
   comment,
   postAuthorId,
   writerId,
+  isFollowing,
 }) {
   return (
     <CommentWrapper>
@@ -20,7 +21,11 @@ export default function Comment({
       <CommentContent>
         <CommentOwner>
           <h1>{username} </h1>
-          {postAuthorId === writerId ? <span>• post's author</span> : <></>}
+          {postAuthorId === writerId ? (
+            <span>• post's author</span>
+          ) : (
+            <span>{isFollowing ? "• following" : <></>}</span>
+          )}
         </CommentOwner>
         <p>{comment}</p>
       </CommentContent>

--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -5,7 +5,13 @@ import {
   CommentWrapper,
 } from "./styles";
 
-export default function Comment({ picture, username, comment }) {
+export default function Comment({
+  picture,
+  username,
+  comment,
+  postAuthorId,
+  writerId,
+}) {
   return (
     <CommentWrapper>
       <CommentIcon>
@@ -14,7 +20,7 @@ export default function Comment({ picture, username, comment }) {
       <CommentContent>
         <CommentOwner>
           <h1>{username} </h1>
-          <span> • teste</span>
+          {postAuthorId === writerId ? <span>• post's author</span> : <></>}
         </CommentOwner>
         <p>{comment}</p>
       </CommentContent>

--- a/src/components/PostBox/Post.jsx
+++ b/src/components/PostBox/Post.jsx
@@ -297,8 +297,13 @@ export default function Post({
       .catch((err) => {});
   }
   function getComments() {
+    const config = {
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+      },
+    };
     api
-      .get(`/comment/${id}`)
+      .get(`/comment/${id}`, config)
       .then((res) => {
         setComments(res.data);
         setCommentsIsOpen(true);
@@ -422,6 +427,7 @@ export default function Post({
               comment={comment.comment}
               writerId={comment.commentWriterId}
               postAuthorId={writerId}
+              isFollowing={comment.isFollowing}
             />
           ))}
           <InputBox>

--- a/src/components/PostBox/Post.jsx
+++ b/src/components/PostBox/Post.jsx
@@ -420,6 +420,8 @@ export default function Post({
               picture={comment.picture}
               username={comment.username}
               comment={comment.comment}
+              writerId={comment.commentWriterId}
+              postAuthorId={writerId}
             />
           ))}
           <InputBox>

--- a/src/components/PostBox/styles.js
+++ b/src/components/PostBox/styles.js
@@ -313,6 +313,7 @@ export const Comments = styled.div`
 `;
 
 export const CommentBox = styled.div`
+  max-width: 600px;
   margin-top: -20px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Adicionado: ternários para saber se o id do dono do comentario é o mesmo do dono do post, caso não seja outro ternario para saber o que deve ter display ao lado do nome do dono do comentario baseado nos follows
OBS: agora a função de carregar comentarios requer que o usuario esteja logado, assim consigo saber se ele segue quem está comentando
fix: css do input de comentarios